### PR TITLE
Update Dependencies for Ubuntu 23.10, gnome-themes-standard -> gnome-themes-extra

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Most of the work is done inside [solarize.sh](https://github.com/apheleia/solarc
 
 ## Requirements
 * Gnome/GTK3 3.14 - 3.22
-* The `gnome-themes-standard` package
+* The `gnome-themes-extra` package
 * The murrine engine. This has different names depending on your distro.
   * `gtk-engine-murrine` (Arch Linux)
   * `gtk2-engines-murrine` (Debian, Ubuntu, elementary OS)

--- a/debian/control
+++ b/debian/control
@@ -10,6 +10,6 @@ Homepage: https://github.com/schemar/solarc-theme
 
 Package: solarc-theme
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, gnome-themes-standard, gtk2-engines-murrine, 
+Depends: ${shlibs:Depends}, ${misc:Depends}, gnome-themes-extra, gtk2-engines-murrine, 
 Description: <insert up to 60 chars description>
  <insert long description, indented with spaces>


### PR DESCRIPTION
The `gnome-themes-standard` transitional package has been removed in Ubuntu 23.10, This PR updates `solarc-theme` to depend on the package `gnome-themes-standard` used to install.